### PR TITLE
👽🐉 Updated with Glitch / Hack session #414

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # HappUI
 
-WebComponent ‹Sentir—Comprendre—Connaître›, following Enrique Pardo's requirements and concept, described at https://happui.org/app/
+![Glitch Badge](https://badge.glitch.me/gfio-happui)
+
+WebComponent ‹Sentir—Comprendre—Connaître›, following Enrique Pardo's
+requirements and concept (described at https://happui.org/app/).
 
 ## Current status
 
 ```html
-<happ-ui title="First"></happ-ui>
-<happ-ui title="Second"></happ-ui>
+    <happ-ui title="Color Wheel 1"
+             sentir="0.75" comprendre="0.75" connaitre="0.75"></happ-ui>
+    <happ-ui title="Color Wheel 2"
+             sentir="0.8" comprendre="0.57" connaitre="0.45"></happ-ui>
 ```
 
 ![Two sample ‹happ-ui› web components](docs/happ-ui-components-sample.png)
@@ -28,10 +33,12 @@ npm i happ-ui
   import 'happ-ui/happ-ui.js';
 </script>
 
-<happ-ui></happ-ui>
+<happ-ui title="Color Wheel"
+         sentir="0.75" comprendre="0.75" connaitre="0.75"></happ-ui>
 ```
 
 ## Demoing with Storybook
+
 To run a local instance of Storybook for your component, run
 
 ```bash
@@ -57,4 +64,4 @@ If you customize the configuration a lot, you can consider moving them to indivi
 npm run watch
 ```
 
-To run a local development server that serves the basic demo located in `index.html`
+To run a local development server that serves the basic demo located in `index.html`.

--- a/index.html
+++ b/index.html
@@ -11,10 +11,14 @@
 
 <body>
   <div id="demo">
-    <happ-ui title="Color Wheel 1"></happ-ui>
-    <happ-ui title="Color Wheel 2"></happ-ui>
-    <happ-ui title="Color Wheel 3"></happ-ui>
-    <happ-ui title="Color Wheel 4"></happ-ui>
+    <happ-ui title="Color Wheel 1"
+             sentir="0.75" comprendre="0.75" connaitre="0.75"></happ-ui>
+    <happ-ui title="Color Wheel 2"
+             sentir="0.8" comprendre="0.57" connaitre="0.45"></happ-ui>
+    <happ-ui title="Color Wheel 3"
+             sentir="0.6" comprendre="0.5" connaitre="0.6"></happ-ui>
+    <happ-ui title="Color Wheel 4"
+             sentir="0.35" comprendre="0.5" connaitre="0.8"></happ-ui>
   </div>
 
   <script type="module">

--- a/src/HappUi.js
+++ b/src/HappUi.js
@@ -1,5 +1,11 @@
 import { html, svg, css, LitElement } from 'lit-element';
 
+// Utility functions
+function clamp( val, min, max) {
+  return val <= min ? min : val >= max ? max : val;
+}
+
+// Web Component definition
 export class HappUi extends LitElement {
   static get styles() {
     return css`
@@ -16,23 +22,54 @@ export class HappUi extends LitElement {
   static get properties() {
     return {
       title: { type: String },
-      counter: { type: Number },
+      sentir: { type: Number }, // Value in between 0.0 … 1.0
+      connaitre: { type: Number }, // idem
+      comprendre: { type: Number }, // idem
     };
   }
 
   constructor() {
     super();
-    this.title = 'Hey there';
-    this.counter = 5;
+    
+    // Observed properties
+    this.title = 'Color Wheel';
+    this._sentir = 0.75;
+    this._connaitre = 0.75;
+    this._comprendre = 0.75;
+
+    // Private properties
+    this.__max = 0.90; // Maximum value of the properties { sentir, connaitre, comprendre }
+    this.__min = 0.10; // Minimum value … idem …
   }
 
-  __increment() {
-    this.counter += 1;
+  get sentir() { return this._sentir; }  
+  set sentir( val) {
+    let oldVal = this._sentir;
+    this._sentir = clamp( val, this.__min, this.__max);
+    this.requestUpdate( 'sentir', oldVal);
+  }
+
+  get connaitre() { return this._connaitre; }
+  set connaitre( val) {
+    let oldVal = this._connaitre;
+    this._connaitre = clamp( val, this.__min, this.__max);
+    this.requestUpdate( 'connaitre', oldVal);
+  }
+
+  get comprendre() { return this._comprendre; }
+  set comprendre( val) {
+    let oldVal = this._comprendre;
+    this._comprendre = clamp( val, this.__min, this.__max);
+    this.requestUpdate( 'comprendre', oldVal);
   }
 
   render() {
     return svg`<svg viewBox="0 0 100 100" aria-label="${this.title}">
       <title>${this.title}</title>
+      <style>
+        .stem { stroke: white; stroke-width: 3.0; }
+        .sprout { stroke: white; stroke-width: 3.0; fill-opacity: 0.0; }
+      </style>
       <defs>
         <filter id="blur" color-interpolation-filters="linear" x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur in="SourceGraphic" stdDeviation="9"/>
@@ -41,19 +78,27 @@ export class HappUi extends LitElement {
           <circle cx="50" cy="50" r="50" fill="white"/>
         </mask>
       </defs>
-      <g mask="url(#circle)" filter="url(#blur)">
-        <rect x="-10" width="110" height="110" fill="blue"/>
-        <rect x="50" width="60" height="110" fill="yellow"/>
-        <polygon points="50,50, 60,110, 40,110" fill="#0f8"/>
-        <polygon points="0,0, 100,0, 100,20, 50,50, 0,20" fill="red"/>
-        <polygon points="0,10, 50,50, 0,30" fill="#f0f"/>
-        <polygon points="100,10, 100,30, 50,50" fill="#f80"/>
+      <g id="background-circle" mask="url(#circle)" filter="url(#blur)">
+        <rect x="-10" width="110" height="110" fill="hsl(240,100%,${this._connaitre*52}%)"/> <!-- blue -->
+        <rect x="50" width="60" height="110" fill="hsl(60,100%,${this._sentir*52}%)"/> <!-- yellow -->
+        <polygon points="50,50, 60,110, 40,110" fill="hsl(150,100%,${(this._connaitre+this._sentir)*26}%)"/> <!-- #0f8 / green -->
+        <polygon points="0,0, 100,0, 100,20, 50,50, 0,20" fill="hsl(0,100%,${this._comprendre*52}%)"/> <!-- red -->
+        <polygon points="0,10, 50,50, 0,30" fill="hsl(300,100%,${(this._connaitre+this._comprendre)*26}%)"/> <!-- #f0f / magenta -->
+        <polygon points="100,10, 100,30, 50,50" fill="hsl(30,100%,${(this._comprendre+this._sentir)*26}%)"/> <!-- #f80 / orange -->
       </g>
-      <g transform="scale( 0.125)">
-        <path id="backcircle" d="M800,400c0,220.91-179.09,400-400,400S0,620.91,0,400,179.09,0,400,0,800,179.09,800,400ZM400,60C212.22,60,60,212.22,60,400S212.22,740,400,740,740,587.78,740,400,587.78,60,400,60Z"/>
-        <path id="comprendre" d="M256.32,492.77a50.54,50.54,0,0,1-47.45,67.57,51,51,0,0,1-13.15-1.74A50.5,50.5,0,1,1,248,478l147.78-85.32,8.5,14.72Zm-25.44,4.3a25.5,25.5,0,1,0-44.17,25.5h0a25.5,25.5,0,0,0,44.17-25.5Z"/>
-        <path id="sentir" d="M408.5,229.36V400h-17V229.18a50.47,50.47,0,1,1,17,.18ZM426,179.5A25.5,25.5,0,1,0,400.5,205,25.53,25.53,0,0,0,426,179.5Z"/>
-        <path id="connaitre" d="M634.44,535.93a50.5,50.5,0,0,1-90.91-43.25L395.75,407.36l8.5-14.72L552.18,478a50.5,50.5,0,0,1,82.26,57.89Zm-31-47.33a25.5,25.5,0,1,0,9.33,34.83h0a25.49,25.49,0,0,0-9.33-34.83Z"/>
+      <g id="pistils">
+        <g id="p0" transform="translate(50 50) rotate(30 0 0)">
+          <line id="p0:stem" class="stem" x1="0" y1="0" x2="${this._sentir * 47 - 5}" y2="0" />
+          <circle id="p0:sprout" class="sprout" cx="${this._sentir * 47}" cy="0" r="5" />
+        </g>
+        <g id="p1" transform="translate(50 50) rotate(150 0 0)">
+          <line id="p1:stem" class="stem" x1="0" y1="0" x2="${this._connaitre * 47 - 5}" y2="0" />
+          <circle id="p1:sprout" class="sprout" cx="${this._connaitre * 47}" cy="0" r="5" />
+        </g>
+        <g id="p2" transform="translate(50 50) rotate(270 0 0)">
+          <line id="p2:stem" class="stem" x1="0" y1="0" x2="${this._comprendre * 47 - 5}" y2="0" />
+          <circle id="p2:sprout" class="sprout" cx="${this._comprendre * 47}" cy="0" r="5" />
+        </g>
       </g>
     </svg>`;
   }


### PR DESCRIPTION
* Refactors and simplifies the SVG of the ‹happ-ui› web component
* Exposes new `sentir`, `connaitre` and `comprendre` attributes and properties…
* … which drive the length of every stem;
* … and change the luminosity of every part of the background color gradient.